### PR TITLE
Add simple Java OJ web app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt gunicorn
+COPY . .
+CMD ["gunicorn", "-w", "4", "server:app", "-b", "0.0.0.0:5000"]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,27 @@
-## a oj basic code
-using for testing homework 
+# Simple Java Online Judge
+
+This project provides a minimal Online Judge (OJ) website for evaluating Java code. It supports user registration, problem management, code submission with automatic judging, and simple exam management. The UI uses Bootstrap for a cleaner look.
+
+## Features
+- User registration and login
+- Submit Java solutions and receive verdicts
+- Admin interface to add problems, exams and test cases
+- Basic exam mode with start and end times plus a scoreboard
+- SQLite database for persistence
+
+## Setup
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Run the server for development:
+   ```bash
+   python server.py
+   ```
+   Or run with Gunicorn for production:
+   ```bash
+   gunicorn -w 4 server:app
+   ```
+3. Open `http://localhost:5000` in your browser.
+
+Use the Admin page to create problems, exams and test cases. Sample problems can be inserted by writing scripts using the models in `app/models.py`.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,16 @@
+from flask import Flask
+from .database import db
+from .routes import register_routes
+
+
+def create_app():
+    app = Flask(__name__)
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///oj.db'
+    app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+    app.config['SECRET_KEY'] = 'secret-key'
+
+    db.init_app(app)
+    register_routes(app)
+    with app.app_context():
+        db.create_all()
+    return app

--- a/app/database.py
+++ b/app/database.py
@@ -1,0 +1,3 @@
+from flask_sqlalchemy import SQLAlchemy
+
+db = SQLAlchemy()

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,43 @@
+from datetime import datetime
+from .database import db
+
+class User(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    username = db.Column(db.String(80), unique=True, nullable=False)
+    password = db.Column(db.String(120), nullable=False)
+    is_admin = db.Column(db.Boolean, default=False)
+
+class Problem(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    title = db.Column(db.String(200), nullable=False)
+    description = db.Column(db.Text, nullable=False)
+    input_desc = db.Column(db.Text, nullable=False)
+    output_desc = db.Column(db.Text, nullable=False)
+    sample_input = db.Column(db.Text, nullable=True)
+    sample_output = db.Column(db.Text, nullable=True)
+
+class TestCase(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    problem_id = db.Column(db.Integer, db.ForeignKey('problem.id'), nullable=False)
+    input_data = db.Column(db.Text, nullable=False)
+    expected_output = db.Column(db.Text, nullable=False)
+
+class Exam(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    title = db.Column(db.String(200), nullable=False)
+    start_time = db.Column(db.DateTime, nullable=False)
+    end_time = db.Column(db.DateTime, nullable=False)
+
+class ExamProblem(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    exam_id = db.Column(db.Integer, db.ForeignKey('exam.id'), nullable=False)
+    problem_id = db.Column(db.Integer, db.ForeignKey('problem.id'), nullable=False)
+
+class Submission(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+    problem_id = db.Column(db.Integer, db.ForeignKey('problem.id'), nullable=False)
+    code = db.Column(db.Text, nullable=False)
+    result = db.Column(db.String(20))
+    timestamp = db.Column(db.DateTime, default=datetime.utcnow)
+    exam_id = db.Column(db.Integer, db.ForeignKey('exam.id'))

--- a/app/routes.py
+++ b/app/routes.py
@@ -1,0 +1,168 @@
+from datetime import datetime
+from flask import render_template, request, redirect, url_for, session, flash
+from werkzeug.security import generate_password_hash, check_password_hash
+from .database import db
+from .models import User, Problem, TestCase, Submission, Exam, ExamProblem
+from .utils import compile_and_run
+
+
+def register_routes(app):
+    @app.route('/')
+    def index():
+        problems = Problem.query.all()
+        exams = Exam.query.order_by(Exam.start_time.desc()).all()
+        return render_template('index.html', problems=problems, exams=exams, user=session.get('user'))
+
+    @app.route('/register', methods=['GET', 'POST'])
+    def register():
+        if request.method == 'POST':
+            username = request.form['username']
+            password = generate_password_hash(request.form['password'])
+            if User.query.filter_by(username=username).first():
+                flash('Username already exists')
+                return redirect(url_for('register'))
+            user = User(username=username, password=password)
+            db.session.add(user)
+            db.session.commit()
+            flash('Registration successful')
+            return redirect(url_for('login'))
+        return render_template('register.html')
+
+    @app.route('/login', methods=['GET', 'POST'])
+    def login():
+        if request.method == 'POST':
+            username = request.form['username']
+            password = request.form['password']
+            user = User.query.filter_by(username=username).first()
+            if user and check_password_hash(user.password, password):
+                session['user'] = {'id': user.id, 'username': user.username, 'is_admin': user.is_admin}
+                return redirect(url_for('index'))
+            flash('Invalid credentials')
+        return render_template('login.html')
+
+    @app.route('/logout')
+    def logout():
+        session.pop('user', None)
+        return redirect(url_for('index'))
+
+    @app.route('/problems/<int:pid>')
+    def problem(pid):
+        prob = Problem.query.get_or_404(pid)
+        exam_id = request.args.get('exam')
+        return render_template('problem.html', problem=prob, exam_id=exam_id, user=session.get('user'))
+
+    @app.route('/submit/<int:pid>', methods=['GET', 'POST'])
+    def submit(pid):
+        prob = Problem.query.get_or_404(pid)
+        exam_id = request.args.get('exam') or request.form.get('exam_id')
+        if request.method == 'POST':
+            code = request.form['code']
+            user_id = session.get('user', {}).get('id')
+            if not user_id:
+                flash('Please login to submit')
+                return redirect(url_for('login'))
+            for case in TestCase.query.filter_by(problem_id=pid).all():
+                ok, output = compile_and_run(code, case.input_data)
+                if not ok:
+                    result = f'Error: {output.strip()}'
+                    break
+                if output.strip() != case.expected_output.strip():
+                    result = 'Wrong Answer'
+                    break
+            else:
+                result = 'Accepted'
+            submission = Submission(user_id=user_id, problem_id=pid, code=code,
+                                   result=result, exam_id=exam_id)
+            db.session.add(submission)
+            db.session.commit()
+            flash(f'Result: {result}')
+            if exam_id:
+                return redirect(url_for('exam', eid=exam_id))
+            return redirect(url_for('problem', pid=pid))
+        return render_template('submit.html', problem=prob, exam_id=exam_id, user=session.get('user'))
+
+    @app.route('/submissions')
+    def submissions():
+        user_id = session.get('user', {}).get('id')
+        if not user_id:
+            flash('Please login to view submissions')
+            return redirect(url_for('login'))
+        subs = Submission.query.filter_by(user_id=user_id).all()
+        return render_template('submissions.html', submissions=subs, user=session.get('user'))
+
+    @app.route('/admin', methods=['GET', 'POST'])
+    def admin():
+        user = session.get('user')
+        if not user or not user.get('is_admin'):
+            flash('Admin only')
+            return redirect(url_for('index'))
+        if request.method == 'POST':
+            title = request.form['title']
+            description = request.form['description']
+            input_desc = request.form['input_desc']
+            output_desc = request.form['output_desc']
+            sample_input = request.form['sample_input']
+            sample_output = request.form['sample_output']
+            prob = Problem(title=title, description=description, input_desc=input_desc,
+                           output_desc=output_desc, sample_input=sample_input, sample_output=sample_output)
+            db.session.add(prob)
+            db.session.commit()
+            flash('Problem added')
+        problems = Problem.query.all()
+        return render_template('admin.html', problems=problems, user=user)
+
+    @app.route('/admin/problem/<int:pid>/testcases', methods=['GET', 'POST'])
+    def manage_testcases(pid):
+        user = session.get('user')
+        if not user or not user.get('is_admin'):
+            flash('Admin only')
+            return redirect(url_for('index'))
+        prob = Problem.query.get_or_404(pid)
+        if request.method == 'POST':
+            input_data = request.form['input_data']
+            expected_output = request.form['expected_output']
+            tc = TestCase(problem_id=pid, input_data=input_data, expected_output=expected_output)
+            db.session.add(tc)
+            db.session.commit()
+            flash('Test case added')
+        testcases = TestCase.query.filter_by(problem_id=pid).all()
+        return render_template('admin_testcase.html', problem=prob, testcases=testcases, user=user)
+
+    @app.route('/admin/exam', methods=['GET', 'POST'])
+    def admin_exam():
+        user = session.get('user')
+        if not user or not user.get('is_admin'):
+            flash('Admin only')
+            return redirect(url_for('index'))
+        if request.method == 'POST':
+            title = request.form['title']
+            start_time = request.form['start_time']
+            end_time = request.form['end_time']
+            exam = Exam(title=title, start_time=start_time, end_time=end_time)
+            db.session.add(exam)
+            db.session.commit()
+            flash('Exam created')
+        exams = Exam.query.all()
+        return render_template('admin_exam.html', exams=exams, user=user)
+
+    @app.route('/exam/<int:eid>')
+    def exam(eid):
+        exam = Exam.query.get_or_404(eid)
+        now = datetime.utcnow()
+        started = now >= exam.start_time
+        ended = now >= exam.end_time
+        problems = [ep.problem for ep in ExamProblem.query.filter_by(exam_id=eid).all()]
+        return render_template('exam.html', exam=exam, problems=problems, started=started, ended=ended, user=session.get('user'))
+
+    @app.route('/exam/<int:eid>/scoreboard')
+    def exam_scoreboard(eid):
+        exam = Exam.query.get_or_404(eid)
+        scores = {}
+        submissions = Submission.query.filter_by(exam_id=eid).all()
+        for sub in submissions:
+            user = User.query.get(sub.user_id)
+            if user.username not in scores:
+                scores[user.username] = 0
+            if sub.result == 'Accepted':
+                scores[user.username] += 1
+        return render_template('scoreboard.html', exam=exam, scores=scores, user=session.get('user'))

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,0 +1,23 @@
+import os
+import subprocess
+import tempfile
+import shutil
+
+
+def compile_and_run(code, input_data, timeout=5):
+    temp_dir = tempfile.mkdtemp()
+    try:
+        source_path = os.path.join(temp_dir, 'Main.java')
+        with open(source_path, 'w') as f:
+            f.write(code)
+        compile_proc = subprocess.run(['javac', source_path], capture_output=True, text=True, timeout=timeout)
+        if compile_proc.returncode != 0:
+            return False, compile_proc.stderr
+        run_proc = subprocess.run(['java', '-cp', temp_dir, 'Main'], input=input_data, capture_output=True, text=True, timeout=timeout)
+        if run_proc.returncode != 0:
+            return False, run_proc.stderr
+        return True, run_proc.stdout
+    except subprocess.TimeoutExpired:
+        return False, 'Time Limit Exceeded'
+    finally:
+        shutil.rmtree(temp_dir)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask==2.2.5
+Flask-SQLAlchemy==3.1.1

--- a/server.py
+++ b/server.py
@@ -1,0 +1,6 @@
+from app import create_app
+
+app = create_app()
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000, debug=True)

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,1 @@
+body { padding-top: 70px; }

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -1,0 +1,20 @@
+{% extends 'layout.html' %}
+{% block content %}
+<h2 class="mb-3">Add Problem</h2>
+<form method="post" class="mb-5">
+  <div class="mb-3"><label class="form-label">Title:<input class="form-control" name="title"></label></div>
+  <div class="mb-3"><label class="form-label">Description:<textarea class="form-control" name="description" rows="5"></textarea></label></div>
+  <div class="mb-3"><label class="form-label">Input Description:<textarea class="form-control" name="input_desc" rows="2"></textarea></label></div>
+  <div class="mb-3"><label class="form-label">Output Description:<textarea class="form-control" name="output_desc" rows="2"></textarea></label></div>
+  <div class="mb-3"><label class="form-label">Sample Input:<textarea class="form-control" name="sample_input" rows="2"></textarea></label></div>
+  <div class="mb-3"><label class="form-label">Sample Output:<textarea class="form-control" name="sample_output" rows="2"></textarea></label></div>
+  <button class="btn btn-primary" type="submit">Add Problem</button>
+</form>
+
+<h2 class="mb-3">Existing Problems</h2>
+<ul class="list-group">
+{% for p in problems %}
+  <li class="list-group-item">{{ p.id }} - {{ p.title }} - <a href="{{ url_for('manage_testcases', pid=p.id) }}">Test Cases</a></li>
+{% endfor %}
+</ul>
+{% endblock %}

--- a/templates/admin_exam.html
+++ b/templates/admin_exam.html
@@ -1,0 +1,17 @@
+{% extends 'layout.html' %}
+{% block content %}
+<h2 class="mb-3">Create Exam</h2>
+<form method="post" class="mb-5">
+  <div class="mb-3"><label class="form-label">Title:<input class="form-control" name="title"></label></div>
+  <div class="mb-3"><label class="form-label">Start Time (YYYY-MM-DD HH:MM:SS):<input class="form-control" name="start_time"></label></div>
+  <div class="mb-3"><label class="form-label">End Time (YYYY-MM-DD HH:MM:SS):<input class="form-control" name="end_time"></label></div>
+  <button class="btn btn-primary" type="submit">Create</button>
+</form>
+
+<h2 class="mb-3">Existing Exams</h2>
+<ul class="list-group">
+{% for e in exams %}
+  <li class="list-group-item"><a href="{{ url_for('exam', eid=e.id) }}">{{ e.title }}</a> ({{ e.start_time }} - {{ e.end_time }})</li>
+{% endfor %}
+</ul>
+{% endblock %}

--- a/templates/admin_testcase.html
+++ b/templates/admin_testcase.html
@@ -1,0 +1,14 @@
+{% extends 'layout.html' %}
+{% block content %}
+<h2 class="mb-3">Test Cases for {{ problem.title }}</h2>
+<form method="post" class="mb-4">
+  <div class="mb-3"><label class="form-label">Input:<textarea class="form-control" name="input_data" rows="2"></textarea></label></div>
+  <div class="mb-3"><label class="form-label">Expected Output:<textarea class="form-control" name="expected_output" rows="2"></textarea></label></div>
+  <button class="btn btn-primary" type="submit">Add Test Case</button>
+</form>
+<ul class="list-group">
+{% for tc in testcases %}
+  <li class="list-group-item">#{{ tc.id }} - <code>{{ tc.input_data|e }}</code> -> <code>{{ tc.expected_output|e }}</code></li>
+{% endfor %}
+</ul>
+{% endblock %}

--- a/templates/exam.html
+++ b/templates/exam.html
@@ -1,0 +1,16 @@
+{% extends 'layout.html' %}
+{% block content %}
+<h2 class="mb-3">{{ exam.title }}</h2>
+<a class="btn btn-secondary mb-3" href="{{ url_for('exam_scoreboard', eid=exam.id) }}">View Scoreboard</a>
+{% if not started %}
+<p class="alert alert-info">Exam not started yet.</p>
+{% elif ended %}
+<p class="alert alert-warning">Exam ended.</p>
+{% else %}
+<ul class="list-group">
+{% for p in problems %}
+  <li class="list-group-item"><a href="{{ url_for('problem', pid=p.id, exam=exam.id) }}">{{ p.title }}</a></li>
+{% endfor %}
+</ul>
+{% endif %}
+{% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,16 @@
+{% extends 'layout.html' %}
+{% block content %}
+<h1 class="mb-4">Problems</h1>
+<div class="list-group mb-5">
+{% for p in problems %}
+  <a class="list-group-item list-group-item-action" href="{{ url_for('problem', pid=p.id) }}">{{ p.title }}</a>
+{% endfor %}
+</div>
+
+<h2 class="mb-3">Exams</h2>
+<ul class="list-group">
+{% for e in exams %}
+  <li class="list-group-item"><a href="{{ url_for('exam', eid=e.id) }}">{{ e.title }}</a> ({{ e.start_time }} - {{ e.end_time }})</li>
+{% endfor %}
+</ul>
+{% endblock %}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Simple OJ</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="{{ url_for('index') }}">Simple OJ</a>
+    <div class="collapse navbar-collapse">
+      <ul class="navbar-nav ms-auto mb-2 mb-lg-0">
+        {% if user %}
+          <li class="nav-item">
+            <span class="navbar-text me-3">Logged in as {{ user.username }}</span>
+          </li>
+          <li class="nav-item"><a class="nav-link" href="{{ url_for('submissions') }}">My Submissions</a></li>
+          {% if user.is_admin %}
+          <li class="nav-item"><a class="nav-link" href="{{ url_for('admin') }}">Admin</a></li>
+          {% endif %}
+          <li class="nav-item"><a class="nav-link" href="{{ url_for('logout') }}">Logout</a></li>
+        {% else %}
+          <li class="nav-item"><a class="nav-link" href="{{ url_for('login') }}">Login</a></li>
+          <li class="nav-item"><a class="nav-link" href="{{ url_for('register') }}">Register</a></li>
+        {% endif %}
+      </ul>
+    </div>
+  </div>
+</nav>
+<div class="container mt-4">
+{% with messages = get_flashed_messages() %}
+  {% if messages %}
+    {% for m in messages %}<div class="alert alert-info">{{ m }}</div>{% endfor %}
+  {% endif %}
+{% endwith %}
+{% block content %}{% endblock %}
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,9 @@
+{% extends 'layout.html' %}
+{% block content %}
+<h2 class="mb-3">Login</h2>
+<form method="post">
+  <div class="mb-3"><label class="form-label">Username: <input class="form-control" name="username"></label></div>
+  <div class="mb-3"><label class="form-label">Password: <input class="form-control" name="password" type="password"></label></div>
+  <button class="btn btn-primary" type="submit">Login</button>
+</form>
+{% endblock %}

--- a/templates/problem.html
+++ b/templates/problem.html
@@ -1,0 +1,12 @@
+{% extends 'layout.html' %}
+{% block content %}
+<h2>{{ problem.title }}</h2>
+<pre>{{ problem.description }}</pre>
+<h3>Input</h3>
+<pre>{{ problem.input_desc }}</pre>
+<h3>Output</h3>
+<pre>{{ problem.output_desc }}</pre>
+{% if problem.sample_input %}<h3>Sample Input</h3><pre>{{ problem.sample_input }}</pre>{% endif %}
+{% if problem.sample_output %}<h3>Sample Output</h3><pre>{{ problem.sample_output }}</pre>{% endif %}
+<a class="btn btn-primary" href="{{ url_for('submit', pid=problem.id, exam=exam_id) }}">Submit</a>
+{% endblock %}

--- a/templates/register.html
+++ b/templates/register.html
@@ -1,0 +1,9 @@
+{% extends 'layout.html' %}
+{% block content %}
+<h2 class="mb-3">Register</h2>
+<form method="post">
+  <div class="mb-3"><label class="form-label">Username: <input class="form-control" name="username"></label></div>
+  <div class="mb-3"><label class="form-label">Password: <input class="form-control" name="password" type="password"></label></div>
+  <button class="btn btn-primary" type="submit">Register</button>
+</form>
+{% endblock %}

--- a/templates/scoreboard.html
+++ b/templates/scoreboard.html
@@ -1,0 +1,12 @@
+{% extends 'layout.html' %}
+{% block content %}
+<h2 class="mb-3">Scoreboard - {{ exam.title }}</h2>
+<table class="table table-striped">
+  <thead><tr><th>User</th><th>Accepted Count</th></tr></thead>
+  <tbody>
+  {% for user, score in scores.items() %}
+  <tr><td>{{ user }}</td><td>{{ score }}</td></tr>
+  {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/templates/submissions.html
+++ b/templates/submissions.html
@@ -1,0 +1,12 @@
+{% extends 'layout.html' %}
+{% block content %}
+<h2 class="mb-3">My Submissions</h2>
+<table class="table table-bordered">
+<thead><tr><th>ID</th><th>Problem</th><th>Result</th><th>Time</th></tr></thead>
+<tbody>
+{% for s in submissions %}
+<tr><td>{{ s.id }}</td><td>{{ s.problem_id }}</td><td>{{ s.result }}</td><td>{{ s.timestamp }}</td></tr>
+{% endfor %}
+</tbody>
+</table>
+{% endblock %}

--- a/templates/submit.html
+++ b/templates/submit.html
@@ -1,0 +1,9 @@
+{% extends 'layout.html' %}
+{% block content %}
+<h2 class="mb-3">Submit for {{ problem.title }}</h2>
+<form method="post">
+  {% if exam_id %}<input type="hidden" name="exam_id" value="{{ exam_id }}">{% endif %}
+  <div class="mb-3"><textarea class="form-control" name="code" rows="20" cols="80"></textarea></div>
+  <button class="btn btn-primary" type="submit">Submit</button>
+</form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- create Flask-based web app for a basic Java Online Judge
- implement improved Bootstrap-based UI
- allow admins to manage testcases and view exam scoreboard
- add Dockerfile and gunicorn instructions

## Testing
- `python3 -m py_compile server.py app/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68899818bc40832e9c5273f03cd7067e